### PR TITLE
support devcontainer vscode

### DIFF
--- a/.devcontainer/.env.example
+++ b/.devcontainer/.env.example
@@ -1,0 +1,9 @@
+# Copy this file to .devcontainer/.env and adjust values if needed.
+
+# Host path to the Geant4 datasets. The path is relative from 
+# the .devcontainer folder to the geant4-datasets folder on the host machine.
+GEANT4_DATASETS_HOST_PATH=../geant4-datasets
+
+# Linux/X11 default values:
+DOCKERDISPLAY=:0
+X11FOLDER=/tmp/.X11-unix

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+{
+	"name": "HidraSim Geant4 DevContainer",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "geant4",
+	"runServices": [
+		"geant4"
+	],
+	"features": {
+		"ghcr.io/devcontainers/features/git:1": {}
+	},
+	"workspaceFolder": "/workspace",
+	"shutdownAction": "stopCompose",
+	"initializeCommand": "${localWorkspaceFolder}/.devcontainer/init-host.sh",
+	"postCreateCommand": "mkdir -p /opt/geant4/data && /opt/geant4/bin/geant4-config --install-datasets && if ! grep -q 'terminal-welcome.sh' ~/.bashrc; then echo -e '\n# Show dev container welcome only for interactive shells\nif [[ $- == *i* ]] && [ -f /workspace/.devcontainer/terminal-welcome.sh ]; then\n  bash /workspace/.devcontainer/terminal-welcome.sh\nfi' >> ~/.bashrc; fi",
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"terminal.integrated.profiles.linux": {
+					"HidraSim Bash": {
+						"path": "/bin/bash",
+						"args": [
+							"-lc",
+							"bash /workspace/.devcontainer/terminal-welcome.sh; exec bash"
+						]
+					}
+				},
+				"terminal.integrated.defaultProfile.linux": "HidraSim Bash"
+			},
+			"extensions": [
+				"ms-vscode.cpptools",
+				"ms-vscode.cmake-tools"
+			]
+		}
+	}
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,64 @@
+version: "3.8"
+
+services:
+  xeyes:
+    image: "carlomt/xeyes"
+    stdin_open: true
+    tty: true
+    environment:
+      - DISPLAY=${DOCKERDISPLAY}
+    volumes:
+      - X11-unix:/tmp/.X11-unix
+
+  gears:
+    image: "carlomt/gears"
+    stdin_open: true
+    tty: true
+    environment:
+      - DISPLAY=${DOCKERDISPLAY}
+    volumes:
+      - X11-unix:/tmp/.X11-unix
+
+  geant4:
+    image: "carlomt/geant4:latest"
+    stdin_open: true
+    tty: true
+    command: sleep infinity
+    volumes:
+      - geant4-datasets:/opt/geant4/data:rw
+      - ..:/workspace:cached
+
+  geant4-gui:
+    image: "carlomt/geant4:latest-gui"
+    stdin_open: true
+    tty: true
+    environment:
+      - DISPLAY=${DOCKERDISPLAY}
+    volumes:
+      - X11-unix:/tmp/.X11-unix
+      - geant4-datasets:/opt/geant4/data:rw
+      - ..:/workspace:cached
+
+  prepare:
+    image: "carlomt/geant4:latest"
+    command: >
+      /bin/bash -lc "/opt/geant4/bin/geant4-config --install-datasets"
+    stdin_open: true
+    tty: true
+    volumes:
+      - geant4-datasets:/opt/geant4/data:rw
+
+volumes:
+  geant4-datasets:
+    driver: local
+    driver_opts:
+      type: "none"
+      o: "bind"
+      device: "${GEANT4_DATASETS_HOST_PATH}"
+
+  X11-unix:
+    driver: local
+    driver_opts:
+      type: "none"
+      o: "bind"
+      device: "${X11FOLDER}"

--- a/.devcontainer/init-host.sh
+++ b/.devcontainer/init-host.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -a
+source "$(dirname "$0")/.env"
+set +a
+
+: "${GEANT4_DATASETS_HOST_PATH:?GEANT4_DATASETS_HOST_PATH not defined in .env}"
+
+mkdir -p "${GEANT4_DATASETS_HOST_PATH}"

--- a/.devcontainer/terminal-welcome.sh
+++ b/.devcontainer/terminal-welcome.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Colors
+RED='\033[1;31m'
+GREEN='\033[1;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[1;34m'
+CYAN='\033[1;36m'
+NC='\033[0m' # No Color
+
+clear
+
+cat << "EOF"
+
+░██     ░██ ░██       ░██                                        ░██                
+░██     ░██           ░██                                                           
+░██     ░██ ░██ ░████████ ░██░████  ░██████            ░███████  ░██░█████████████  
+░██████████ ░██░██    ░██ ░███           ░██  ░██████ ░██        ░██░██   ░██   ░██ 
+░██     ░██ ░██░██    ░██ ░██       ░███████           ░███████  ░██░██   ░██   ░██ 
+░██     ░██ ░██░██   ░███ ░██      ░██   ░██                 ░██ ░██░██   ░██   ░██ 
+░██     ░██ ░██ ░█████░██ ░██       ░█████░██          ░███████  ░██░██   ░██   ░██ 
+                                                                                    
+                                                                                    
+                                                                                    
+
+EOF
+
+
+
+
+if [ ! -d "/opt/geant4/data" ] || [ -z "$(ls -A /opt/geant4/data 2>/dev/null)" ]; then
+	DATASETS_STATUS="${RED}⚠️  /opt/geant4/data empty or not mounted!${NC}"
+else
+	DATASETS_STATUS="${GREEN}✅  /opt/geant4/data${NC}"
+fi
+
+G4VER="$(source /opt/geant4/bin/geant4.sh >/dev/null 2>&1 && geant4-config --version 2>/dev/null || echo 'not sourced')"
+
+
+printf "${CYAN}🧪  Welcome to the HidraSim Geant4 Dev Container!  🧪${NC}\n"
+printf "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
+printf "${CYAN}📦  Project repo:${NC}   https://github.com/lopezzot/DREMTubes\n"
+printf "${CYAN}📄  Docs:${NC}           README.md in /workspace\n"
+printf "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
+printf "${CYAN}🔬  Geant4 version:${NC} ${GREEN}$G4VER${NC}\n"
+printf "${CYAN}🗄️   Datasets mount:${NC} $DATASETS_STATUS\n"
+printf "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
+printf "${GREEN}⚡  Reminder:${NC} Before building or running, type:\n"
+printf "   ${BLUE}source /opt/geant4/bin/geant4.sh${NC}\n\n"
+printf "${CYAN}🔧  Build commands:${NC}\n"
+printf "   ${GREEN}mkdir /workspace/build${NC}\n   ${GREEN}cd /workspace/build${NC}\n   ${GREEN}cmake ..${NC}\n   ${GREEN}make -j\$(nproc)${NC}\n\n"
+printf "${CYAN}🚀  Run commands:${NC}\n"
+printf "   ${GREEN}cd /workspace/build${NC}\n   ${GREEN}./DREMTubes -m DREMTubes_run.mac -t 2 -pl FTFP_BERT${NC}\n\n"
+
+printf "${GREEN}🎉  Happy simulating!${NC} 🚀\n\n"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 *.root
 analysis/*.root
+.devcontainer/.env

--- a/README.md
+++ b/README.md
@@ -112,7 +112,29 @@ Parser options
    ```sh
    ./DREMTubes -m DREMTubes_run.mac -t 2 -pl FTFP_BERT
    ```
-   
+
+### Build, compile and execute on local machine using vscode devcontainer
+
+1. git clone the repo
+   ```sh
+   git clone https://github.com/lopezzot/DREMTubes.git
+   cd DREMTubes
+   ```
+
+2. configure `.env` file
+   ```sh
+   cp .devcontainer/.env.example .devcontainer/.env
+   ```
+   in this new file edit the `GEANT4_DATASETS_HOST_PATH` variable with the path on your local machine where you want to store the Geant4 datasets (example: `GEANT4_DATASETS_HOST_PATH=$HOME/geant4-datasets`).
+
+3. open the folder with vscode and open the devcontainer
+   ```sh
+   code .
+   ```
+   and click on "Reopen in container" when prompted, or open the command palette and search for "Dev Containers: Reopen in Container". This will build the docker image and start the container.
+
+At this point you have an environment set up with Geant4 and all the needed dependencies. You should follow instructions in the terminal to build and execute the code.
+
 ### Submit a job with HTCondor on lxplus -> To be tested after Geant4-11
 1. git clone the repo
    ```sh


### PR DESCRIPTION
Small change to add VSCode devcontainer support.

TL;DR: prepare a full Geant4 environment on a local machine (no cvmfs) with 1 click

This PR gives the possibility to get a complete setup environment to run the simulation on a local computer. README.md updated. Based on https://github.com/carlomt/docker-geant4/blob/main/docker-compose.yml