### PR TITLE
Add per-fiber and per-tower geometry maps (CSV) and Python plots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 build/
+build-container/
 *.root
+*.csv
 analysis/*.root
 .devcontainer/.env

--- a/FiberMap.md
+++ b/FiberMap.md
@@ -1,0 +1,97 @@
+# Per-fiber geometry map (CSV)
+
+The simulation can dump a CSV file describing every **SiPM-readout fiber** of the
+calorimeter, one row per fiber. It is meant as a lookup table to connect an entry of the
+output vectors (`VectorSignals` / `VectorSignalsCher`) to the physical fiber that produced
+it: its type, its position, and its indices.
+
+Only fibers belonging to SiPM towers (the towers listed in `SiPMMod[]` in
+`include/DREMTubesGeoPar.hh`) are written. PMT-readout towers are **not** included.
+
+## How to produce it
+
+Add the UI command before `/run/initialize` in your macro:
+
+```
+/tbgeo/fibermap fibers.csv
+/run/initialize
+...
+/run/beamOn 1
+```
+
+The file is written once, when the geometry is built (master thread), so a run with a
+single event is enough. If the command is not given, no file is written. The path is
+relative to the working directory. On completion the program prints:
+
+```
+WriteFiberMap: wrote <N> SiPM fiber rows to '<path>' (<Ncol> columns x <Nrow> rows).
+```
+
+## Reference frame and conventions
+
+- Coordinates are given in the **calorimeter-surface frame with no rotation applied**:
+  neither the test-beam platform tilt (`/tbgeo/vertrot`, `/tbgeo/horizrot`) nor the
+  internal 90° module rotation (`irot`) affect the values. `x` is horizontal, `y` is
+  vertical, both in **mm**.
+- `global_row` / `global_col` are **geometric ranks**: all distinct `y` (resp. `x`)
+  positions of the SiPM fibers are sorted, and each fiber gets the index of its position.
+  Origin is **bottom-left**: `global_row = 0` is the smallest `y` (bottom),
+  `global_col = 0` is the smallest `x` (left). Positions closer than 0.3 mm are treated as
+  the same row/column.
+- Because the fibers are hex-packed, scintillating (even rows) and Cherenkov (odd rows)
+  fibers are staggered by half a tube in `x`, so they occupy **interleaved** columns. As a
+  consequence, a given `(global_row, global_col)` cell holds at most one fiber, and the
+  exact bottom-left *corner* may be empty (the fiber with the smallest `y` is generally not
+  the one with the smallest `x`).
+
+## Columns
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `output_index` | int | Index into the output vector for this fiber, exactly as filled by the stepping action: `SiPMTower * NoFibersTower + copynumber`. Range `0 .. NoFibersTower*NoModulesSiPM - 1`. |
+| `output_vector` | string | Which output vector this fiber fills: `VectorSignals` (scintillating) or `VectorSignalsCher` (Cherenkov). |
+| `fiber_type` | char | `S` = scintillating, `C` = Cherenkov. Equivalent to `output_vector`. |
+| `x` | float (mm) | Global x in the calorimeter-surface frame (no rotation). |
+| `y` | float (mm) | Global y in the calorimeter-surface frame (no rotation). |
+| `global_row` | int | Geometric rank of `y` over all SiPM fibers; `0` = bottom. |
+| `global_col` | int | Geometric rank of `x` over all SiPM fibers; `0` = left. |
+| `local_row` | int | Row index within the module, `0` = bottom. Equal to the fiber row index (`0 .. NofFibersrow-1`). |
+| `local_col` | int | Column index within the module, `0` = left. Equal to `NofFiberscolumn-1 - column`. |
+| `tower_id` | int | Tower/module ID (`modflag` value), i.e. the module copy number. |
+| `mod_grid_col` | int | Column of the module in the calorimeter module grid. |
+| `mod_grid_row` | int | Row of the module in the calorimeter module grid. |
+| `module_x` | float (mm) | x of the module centre (calorimeter frame). |
+| `module_y` | float (mm) | y of the module centre (calorimeter frame). |
+| `copynumber` | int | Fiber copy number within its module (= `SiPMID`): `(NofFibersrow/2)*column + row/2`, range `0 .. NoFibersTower-1`. |
+| `pv_name` | string | Geant4 physical-volume name of the fiber, e.g. `S_column_12_row_4`. |
+
+Notes:
+- `output_index = SiPMTower * NoFibersTower + copynumber`, where `SiPMTower` is the
+  position of `tower_id` in `SiPMMod[]` (0-based). The same `copynumber` value appears once
+  per SiPM tower (with a different `output_index`).
+- All geometry sizes (`NoFibersTower`, `SiPMMod`, `NofFiberscolumn`, `NofFibersrow`, …) are
+  compile-time constants selected by the active block in `include/DREMTubesGeoPar.hh`. The
+  CSV always reflects the block that was compiled in.
+
+## Example
+
+For the currently active geometry (8 SiPM towers `{17,22,27,32,37,42,47,52}` stacked
+vertically, `NoFibersTower = 512`) the file has `8192` data rows and a `128 × 128` grid.
+First data rows:
+
+```
+output_index,output_vector,fiber_type,x,y,global_row,global_col,local_row,local_col,tower_id,mod_grid_col,mod_grid_row,module_x,module_y,copynumber,pv_name
+0,VectorSignals,S,63.5000,-110.0455,0,127,0,63,17,2,5,0.0000,-97.0480,0,S_column_0_row_0
+1,VectorSignals,S,63.5000,-106.5795,2,127,2,63,17,2,5,0.0000,-97.0480,1,S_column_0_row_2
+2,VectorSignals,S,63.5000,-103.1135,4,127,4,63,17,2,5,0.0000,-97.0480,2,S_column_0_row_4
+```
+
+## Visualization
+
+`analysis/plot_fibers.py` draws the fibers as circles (x, y in mm), optionally colored
+and/or labeled by any column:
+
+```
+python analysis/plot_fibers.py fibers.csv --color fiber_type
+python analysis/plot_fibers.py fibers.csv --color output_index --cmap viridis -o fibers.png
+```

--- a/TowerMap.md
+++ b/TowerMap.md
@@ -1,0 +1,96 @@
+# Per-tower geometry map (CSV)
+
+The simulation can dump a CSV file describing every **active tower** (module) of the
+calorimeter, one row per tower, including whether the tower is read out by **SiPM** or
+**PMT** and how its signal maps onto the output vectors. It is the tower-level companion of
+the per-fiber map documented in [`FiberMap.md`](FiberMap.md).
+
+Unlike the fiber map (SiPM only), the tower map contains **all** active towers.
+
+## How to produce it
+
+Add the UI command before `/run/initialize` in your macro:
+
+```
+/tbgeo/towermap towers.csv
+/run/initialize
+...
+/run/beamOn 1
+```
+
+The file is written once, when the geometry is built (master thread), so a single event is
+enough. Both maps can be requested in the same run (`/tbgeo/fibermap` and
+`/tbgeo/towermap`). On completion the program prints:
+
+```
+WriteTowerMap: wrote <N> tower rows to '<path>' (<Ncol> columns x <Nrow> rows).
+```
+
+## Reference frame and conventions
+
+- Coordinates are the **module centre** in the **calorimeter-surface frame with no rotation
+  applied** (neither the platform tilt nor the `irot` 90° module rotation). Units are mm.
+- `global_row` / `global_col` are **geometric ranks** of the tower centres, origin
+  **bottom-left** (`global_row = 0` = smallest `y`, `global_col = 0` = smallest `x`), the
+  same convention as the fiber map.
+
+## Columns
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `tower_id` | int | Tower/module ID (`modflag` value = module copy number). |
+| `readout` | string | `SiPM` if the tower is in `SiPMMod[]`, otherwise `PMT`. |
+| `sipm_slot` | int | 0-based position of the tower in `SiPMMod[]` (the `SiPMTower` index), or `-1` for PMT towers. |
+| `x` | float (mm) | Tower centre x (calorimeter frame, no rotation). |
+| `y` | float (mm) | Tower centre y (calorimeter frame, no rotation). |
+| `global_row` | int | Geometric rank of `y` over all towers; `0` = bottom. |
+| `global_col` | int | Geometric rank of `x` over all towers; `0` = left. |
+| `mod_grid_col` | int | Column of the tower in the calorimeter module grid (raw loop index). |
+| `mod_grid_row` | int | Row of the tower in the calorimeter module grid (raw loop index). |
+| `output_scin_vector` | string | Output vector for the scintillating signal: `VectorSignals` (SiPM) or `VecSPMT` (PMT). |
+| `output_cher_vector` | string | Output vector for the Cherenkov signal: `VectorSignalsCher` (SiPM) or `VecCPMT` (PMT). |
+| `output_index_base` | int | Base index of this tower in its output vectors (see below). |
+| `n_fibers` | int | Total number of tubes in the tower, `NofFiberscolumn*NofFibersrow` (scintillating + Cherenkov). |
+| `module_dx` | float (mm) | Module footprint width (x). |
+| `module_dy` | float (mm) | Module footprint height (y). |
+| `module_z` | float (mm) | Longitudinal length of the module/fibers (`moduleZ`). |
+
+### `output_index_base` semantics
+
+- **SiPM tower**: the fibers fill `VectorSignals` / `VectorSignalsCher` **per fiber**,
+  starting at `output_index_base = sipm_slot * NoFibersTower`. Fiber `k` of the tower
+  (`copynumber = k`) is at index `output_index_base + k`. See the per-fiber map for the
+  individual entries.
+- **PMT tower**: the whole tower is summed into a **single** entry
+  `VecSPMT[output_index_base]` / `VecCPMT[output_index_base]`, where
+  `output_index_base = tower_id`.
+
+## Example
+
+For the currently active geometry the file has `70` tower rows (62 PMT + 8 SiPM). The 8 SiPM
+towers `{17,22,27,32,37,42,47,52}` form a vertical stack (`mod_grid_col = 2`) with
+`sipm_slot` `0…7` and `output_index_base` `0, 512, … , 3584`.
+
+```
+tower_id,readout,sipm_slot,x,y,global_row,global_col,mod_grid_col,mod_grid_row,output_scin_vector,output_cher_vector,output_index_base,n_fibers,module_dx,module_dy,module_z
+17,SiPM,0,0.0000,-97.0480,5,2,2,5,VectorSignals,VectorSignalsCher,0,1024,129.0000,28.3057,2500.0000
+10,PMT,-1,256.0000,-124.7760,4,4,0,4,VecSPMT,VecCPMT,10,1024,129.0000,28.3057,2500.0000
+```
+
+## Visualization
+
+`analysis/plot_towers.py` draws the towers as rectangles (x, y in mm), optionally
+colored and/or labeled by any column:
+
+```
+python analysis/plot_towers.py towers.csv --color readout --label tower_id
+python analysis/plot_towers.py towers.csv --color output_index_base --cmap plasma -o towers.png
+```
+
+### Note on the active geometry
+
+In the currently compiled `modflag` block, tower id `1` is assigned to **two** physical
+modules (grid rows 1 and 4) and id `11` is unused. The tower map lists both `tower_id = 1`
+rows (different `y` / `mod_grid_row`); note that their PMT signals therefore add into the
+same `VecSPMT[1]` / `VecCPMT[1]` entry. This is a property of the geometry configuration,
+not of the map.

--- a/analysis/plot_fibers.py
+++ b/analysis/plot_fibers.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Plot the SiPM fibers of the HiDRa calorimeter from a fiber-map CSV.
+
+The CSV is produced by the simulation with the macro command
+``/tbgeo/fibermap <path>`` (see FiberMap.md). Each fiber is drawn as a circle
+at its (x, y) position, with the axes in millimetres.
+
+Optionally color and/or write a label inside each fiber by giving the name of a
+CSV column.
+
+Examples
+--------
+    python plot_fibers.py fibers.csv
+    python plot_fibers.py fibers.csv --color fiber_type
+    python plot_fibers.py fibers.csv --color output_index --cmap viridis
+    python plot_fibers.py fibers.csv --label copynumber -o fibers.png
+"""
+import argparse
+
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+from matplotlib.collections import PatchCollection
+from matplotlib.patches import Circle
+
+
+def color_patches(ax, pc, df, column, cmap):
+    """Color a PatchCollection by ``column``; add colorbar/legend as needed."""
+    if column is None:
+        pc.set_facecolor("#7fb3ff")
+        pc.set_edgecolor("0.3")
+        pc.set_linewidth(0.2)
+        ax.add_collection(pc)
+        return
+
+    series = df[column]
+    if pd.api.types.is_numeric_dtype(series):
+        pc.set_array(series.to_numpy())
+        pc.set_cmap(cmap or "viridis")
+        pc.set_edgecolor("none")
+        ax.add_collection(pc)
+        cbar = ax.figure.colorbar(pc, ax=ax, fraction=0.046, pad=0.04)
+        cbar.set_label(column)
+    else:
+        cats = list(pd.unique(series.astype(str)))
+        qual = plt.get_cmap(cmap or "tab10")
+        lut = {c: qual(i % qual.N) for i, c in enumerate(cats)}
+        pc.set_facecolor([lut[str(v)] for v in series])
+        pc.set_edgecolor("0.3")
+        pc.set_linewidth(0.2)
+        ax.add_collection(pc)
+        handles = [
+            plt.Line2D([0], [0], marker="o", linestyle="", markeredgecolor="0.3",
+                       markerfacecolor=lut[c], label=c)
+            for c in cats
+        ]
+        ax.legend(handles=handles, title=column, loc="upper right", fontsize=8)
+
+
+COLUMNS = """\
+Columns available for --color / --label (from /tbgeo/fibermap CSV):
+  output_index    index into VectorSignals/VectorSignalsCher for this fiber
+  output_vector   VectorSignals (S) or VectorSignalsCher (C)
+  fiber_type      S = scintillating, C = Cherenkov
+  x, y            fiber position in mm (calorimeter frame, no rotation)
+  global_row      geometric row rank over SiPM fibers (0 = bottom)
+  global_col      geometric column rank over SiPM fibers (0 = left)
+  local_row       row within the module (0 = bottom)
+  local_col       column within the module (0 = left)
+  tower_id        tower/module id (modflag)
+  mod_grid_col    module column in the calorimeter grid
+  mod_grid_row    module row in the calorimeter grid
+  module_x        module centre x in mm
+  module_y        module centre y in mm
+  copynumber      fiber copy number within the module (= SiPMID)
+  pv_name         Geant4 physical-volume name, e.g. S_column_12_row_4
+(Any other numeric or categorical column present in the CSV also works.)"""
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description="Plot SiPM fibers as circles (x, y in mm).",
+        epilog=COLUMNS,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("csv", help="fiber-map CSV (from /tbgeo/fibermap)")
+    p.add_argument("--tower", type=int, nargs="+", metavar="ID",
+                   help="only plot fibers of the given tower_id(s)")
+    p.add_argument("--color", help="column name to color the fibers by")
+    p.add_argument("--label", help="column name to write inside each fiber")
+    p.add_argument("--radius", type=float, default=1.0,
+                   help="fiber circle radius in mm (default: 1.0)")
+    p.add_argument("--cmap", help="matplotlib colormap name")
+    p.add_argument("--fontsize", type=float, default=4.0, help="label font size")
+    p.add_argument("--figsize", type=float, nargs=2, default=(8.0, 8.0),
+                   metavar=("W", "H"), help="figure size in inches")
+    p.add_argument("-o", "--output", help="save figure to this file instead of showing")
+    args = p.parse_args()
+
+    df = pd.read_csv(args.csv)
+    for col in ("x", "y"):
+        if col not in df.columns:
+            p.error(f"column '{col}' not found in {args.csv}")
+    for col in (args.color, args.label):
+        if col is not None and col not in df.columns:
+            p.error(f"column '{col}' not found in {args.csv}")
+
+    if args.tower is not None:
+        if "tower_id" not in df.columns:
+            p.error(f"column 'tower_id' not found in {args.csv}")
+        df = df[df.tower_id.isin(args.tower)]
+        if df.empty:
+            available = sorted(int(t) for t in pd.read_csv(args.csv).tower_id.unique())
+            p.error(f"no fibers for tower_id {args.tower}; available: {available}")
+
+    fig, ax = plt.subplots(figsize=tuple(args.figsize))
+    patches = [Circle((x, y), args.radius) for x, y in zip(df.x, df.y)]
+    color_patches(ax, PatchCollection(patches, match_original=False),
+                  df, args.color, args.cmap)
+
+    if args.label:
+        if len(df) > 3000:
+            print(f"warning: labeling {len(df)} fibers, this may be slow/dense")
+        for x, y, v in zip(df.x, df.y, df[args.label]):
+            ax.text(x, y, str(v), ha="center", va="center", fontsize=args.fontsize)
+
+    r = args.radius
+    ax.set_xlim(df.x.min() - 2 * r, df.x.max() + 2 * r)
+    ax.set_ylim(df.y.min() - 2 * r, df.y.max() + 2 * r)
+    ax.set_aspect("equal")
+    ax.set_xlabel("x [mm]")
+    ax.set_ylabel("y [mm]")
+    title = "SiPM fibers"
+    if args.tower:
+        title += f" — tower {', '.join(str(t) for t in args.tower)}"
+    if args.color:
+        title += f" — colored by {args.color}"
+    ax.set_title(title)
+    fig.tight_layout()
+
+    if args.output:
+        fig.savefig(args.output, dpi=150)
+        print(f"saved {args.output}")
+    else:
+        plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/plot_fibers.py
+++ b/analysis/plot_fibers.py
@@ -10,14 +10,13 @@ CSV column.
 
 Examples
 --------
-    python plot_fibers.py fibers.csv
-    python plot_fibers.py fibers.csv --color fiber_type
-    python plot_fibers.py fibers.csv --color output_index --cmap viridis
-    python plot_fibers.py fibers.csv --label copynumber -o fibers.png
+    python analysis/plot_fibers.py fibers.csv
+    python analysis/plot_fibers.py fibers.csv --color fiber_type
+    python analysis/plot_fibers.py fibers.csv --color output_index --cmap viridis
+    python analysis/plot_fibers.py fibers.csv --label copynumber -o fibers.png
 """
 import argparse
 
-import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 from matplotlib.collections import PatchCollection

--- a/analysis/plot_towers.py
+++ b/analysis/plot_towers.py
@@ -10,13 +10,12 @@ CSV column.
 
 Examples
 --------
-    python plot_towers.py towers.csv --label tower_id
-    python plot_towers.py towers.csv --color readout --label tower_id
-    python plot_towers.py towers.csv --color output_index_base --cmap plasma -o towers.png
+    python analysis/plot_towers.py towers.csv --label tower_id
+    python analysis/plot_towers.py towers.csv --color readout --label tower_id
+    python analysis/plot_towers.py towers.csv --color output_index_base --cmap plasma -o towers.png
 """
 import argparse
 
-import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 from matplotlib.collections import PatchCollection

--- a/analysis/plot_towers.py
+++ b/analysis/plot_towers.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Plot the towers (modules) of the HiDRa calorimeter from a tower-map CSV.
+
+The CSV is produced by the simulation with the macro command
+``/tbgeo/towermap <path>`` (see TowerMap.md). Each tower is drawn as a rectangle
+centred at its (x, y) position with size (module_dx, module_dy); axes in mm.
+
+Optionally color and/or write a label inside each module by giving the name of a
+CSV column.
+
+Examples
+--------
+    python plot_towers.py towers.csv --label tower_id
+    python plot_towers.py towers.csv --color readout --label tower_id
+    python plot_towers.py towers.csv --color output_index_base --cmap plasma -o towers.png
+"""
+import argparse
+
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+from matplotlib.collections import PatchCollection
+from matplotlib.patches import Rectangle
+
+
+def color_patches(ax, pc, df, column, cmap):
+    """Color a PatchCollection by ``column``; add colorbar/legend as needed."""
+    if column is None:
+        pc.set_facecolor("#e6e6e6")
+        pc.set_edgecolor("0.2")
+        pc.set_linewidth(0.6)
+        ax.add_collection(pc)
+        return
+
+    series = df[column]
+    if pd.api.types.is_numeric_dtype(series):
+        pc.set_array(series.to_numpy())
+        pc.set_cmap(cmap or "viridis")
+        pc.set_edgecolor("0.2")
+        pc.set_linewidth(0.6)
+        ax.add_collection(pc)
+        cbar = ax.figure.colorbar(pc, ax=ax, fraction=0.046, pad=0.04)
+        cbar.set_label(column)
+    else:
+        cats = list(pd.unique(series.astype(str)))
+        qual = plt.get_cmap(cmap or "tab10")
+        lut = {c: qual(i % qual.N) for i, c in enumerate(cats)}
+        pc.set_facecolor([lut[str(v)] for v in series])
+        pc.set_edgecolor("0.2")
+        pc.set_linewidth(0.6)
+        ax.add_collection(pc)
+        handles = [
+            plt.Line2D([0], [0], marker="s", linestyle="", markeredgecolor="0.2",
+                       markerfacecolor=lut[c], label=c)
+            for c in cats
+        ]
+        ax.legend(handles=handles, title=column, loc="upper right", fontsize=8)
+
+
+COLUMNS = """\
+Columns available for --color / --label (from /tbgeo/towermap CSV):
+  tower_id            tower/module id (modflag)
+  readout             SiPM or PMT
+  sipm_slot           position in SiPMMod[] (0-based), or -1 for PMT
+  x, y                tower centre in mm (calorimeter frame, no rotation)
+  global_row          geometric row rank over towers (0 = bottom)
+  global_col          geometric column rank over towers (0 = left)
+  mod_grid_col        module column in the calorimeter grid
+  mod_grid_row        module row in the calorimeter grid
+  output_scin_vector  VectorSignals (SiPM) or VecSPMT (PMT)
+  output_cher_vector  VectorSignalsCher (SiPM) or VecCPMT (PMT)
+  output_index_base   base index of the tower in its output vectors
+  n_fibers            number of tubes in the tower
+  module_dx           module width in mm
+  module_dy           module height in mm
+  module_z            module length in mm
+(Any other numeric or categorical column present in the CSV also works.)"""
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description="Plot towers as rectangles (x, y in mm).",
+        epilog=COLUMNS,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("csv", help="tower-map CSV (from /tbgeo/towermap)")
+    p.add_argument("--color", help="column name to color the modules by")
+    p.add_argument("--label", help="column name to write inside each module")
+    p.add_argument("--cmap", help="matplotlib colormap name")
+    p.add_argument("--fontsize", type=float, default=6.0, help="label font size")
+    p.add_argument("--figsize", type=float, nargs=2, default=(8.0, 10.0),
+                   metavar=("W", "H"), help="figure size in inches")
+    p.add_argument("-o", "--output", help="save figure to this file instead of showing")
+    args = p.parse_args()
+
+    df = pd.read_csv(args.csv)
+    for col in ("x", "y", "module_dx", "module_dy"):
+        if col not in df.columns:
+            p.error(f"column '{col}' not found in {args.csv}")
+    for col in (args.color, args.label):
+        if col is not None and col not in df.columns:
+            p.error(f"column '{col}' not found in {args.csv}")
+
+    fig, ax = plt.subplots(figsize=tuple(args.figsize))
+    patches = [
+        Rectangle((x - dx / 2.0, y - dy / 2.0), dx, dy)
+        for x, y, dx, dy in zip(df.x, df.y, df.module_dx, df.module_dy)
+    ]
+    color_patches(ax, PatchCollection(patches, match_original=False),
+                  df, args.color, args.cmap)
+
+    if args.label:
+        for x, y, v in zip(df.x, df.y, df[args.label]):
+            ax.text(x, y, str(v), ha="center", va="center", fontsize=args.fontsize)
+
+    xpad = df.module_dx.max()
+    ypad = df.module_dy.max()
+    ax.set_xlim((df.x - df.module_dx / 2).min() - 0.2 * xpad,
+                (df.x + df.module_dx / 2).max() + 0.2 * xpad)
+    ax.set_ylim((df.y - df.module_dy / 2).min() - 0.2 * ypad,
+                (df.y + df.module_dy / 2).max() + 0.2 * ypad)
+    ax.set_aspect("equal")
+    ax.set_xlabel("x [mm]")
+    ax.set_ylabel("y [mm]")
+    title = "Calorimeter towers"
+    if args.color:
+        title += f" — colored by {args.color}"
+    ax.set_title(title)
+    fig.tight_layout()
+
+    if args.output:
+        fig.savefig(args.output, dpi=150)
+        print(f"saved {args.output}")
+    else:
+        plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/include/DREMTubesDetectorConstruction.hh
+++ b/include/DREMTubesDetectorConstruction.hh
@@ -19,6 +19,11 @@
 #include "G4TwoVector.hh"
 #include "G4ExtrudedSolid.hh"
 
+//Includers from C++
+//
+#include <vector>
+#include <string>
+
 //Include geometrical parameters
 #include "DREMTubesGeoPar.hh"
 #include "DREMTubesGeoMessenger.hh"
@@ -87,6 +92,10 @@ class DREMTubesDetectorConstruction : public G4VUserDetectorConstruction {
         void SetYshift(const G4double& val) {fYshift=val;};
         void SetOrzrot(const G4double& val) {fOrzrot=val;};
         void SetVerrot(const G4double& val) {fVerrot=val;};
+        void SetFiberMapPath(const G4String& val) {fFiberMapPath=val;};
+        G4String GetFiberMapPath() const {return fFiberMapPath;};
+        void SetTowerMapPath(const G4String& val) {fTowerMapPath=val;};
+        G4String GetTowerMapPath() const {return fTowerMapPath;};
 
 
 
@@ -98,10 +107,26 @@ class DREMTubesDetectorConstruction : public G4VUserDetectorConstruction {
 	std::vector<G4TwoVector> calcmod(double radius, int nrow, int ncol); 
 
     private:
-        
+
         //Mandatory method for Geant4
         //
         G4VPhysicalVolume* DefineVolumes();
+
+        //Per-fiber geometry map (CSV) support
+        //
+        //Recorded during DefineVolumes(): one module placement per active tower,
+        //and the fiber-local table (placed once into the shared module volume).
+        struct ModulePlacement { G4int towerID; G4double mx, my; G4int gridCol, gridRow; };
+        struct FiberLocal { char type; G4int colInMod, rowInMod, copyNumber;
+                            G4double lx, ly; std::string pvName; };
+        std::vector<ModulePlacement> fModulePlacements;
+        std::vector<FiberLocal> fFiberLocals;
+        G4double fTubeRadius{1.*mm}; //tube radius, for row/column binning tolerance
+        G4double fModuleX{0.}, fModuleY{0.}; //module footprint (width,height), for tower map
+        //Write the per-fiber CSV to fFiberMapPath (called once, master thread).
+        void WriteFiberMap() const;
+        //Write the per-tower CSV to fTowerMapPath (called once, master thread).
+        void WriteTowerMap() const;
 
         //Members
         //
@@ -119,6 +144,11 @@ class DREMTubesDetectorConstruction : public G4VUserDetectorConstruction {
         //Parameters selectable via UI
         //
         G4double fXshift{0.}, fYshift{0.}, fVerrot{0.}, fOrzrot{0.};
+
+        //Paths for the geometry maps; empty = disabled
+        //
+        G4String fFiberMapPath{""};
+        G4String fTowerMapPath{""};
 
 };
 

--- a/include/DREMTubesGeoMessenger.hh
+++ b/include/DREMTubesGeoMessenger.hh
@@ -14,6 +14,7 @@
 #include "G4UImessenger.hh"
 #include "G4UIdirectory.hh"
 #include "G4UIcmdWithADoubleAndUnit.hh"
+#include "G4UIcmdWithAString.hh"
 
 //Includers from project files
 //
@@ -37,6 +38,8 @@ class DREMTubesGeoMessenger final : public G4UImessenger {
         G4UIcmdWithADoubleAndUnit *fYshiftcmd;
         G4UIcmdWithADoubleAndUnit *fOrzrotcmd;
         G4UIcmdWithADoubleAndUnit *fVerrotcmd;
+        G4UIcmdWithAString *fFiberMapcmd;
+        G4UIcmdWithAString *fTowerMapcmd;
 
 };
 

--- a/src/DREMTubesDetectorConstruction.cc
+++ b/src/DREMTubesDetectorConstruction.cc
@@ -20,6 +20,7 @@
 #include <iomanip>
 #include <algorithm>
 #include "G4Threading.hh"
+#include "G4ApplicationState.hh"
 #include "G4Material.hh"
 #include "G4NistManager.hh"
 #include "G4Box.hh"
@@ -79,9 +80,13 @@ DREMTubesGeoMessenger::DREMTubesGeoMessenger(DREMTubesDetectorConstruction* DetC
     fFiberMapcmd = new G4UIcmdWithAString("/tbgeo/fibermap", this);
     fFiberMapcmd->SetParameterName("path",/*omittable=*/false);
     fFiberMapcmd->SetGuidance("Write per-fiber geometry map (one row per SiPM fiber) to the given CSV path");
+    // The map is written during geometry construction (/run/initialize), so the
+    // path must be set beforehand: only allow the command in the PreInit state.
+    fFiberMapcmd->AvailableForStates(G4State_PreInit);
     fTowerMapcmd = new G4UIcmdWithAString("/tbgeo/towermap", this);
     fTowerMapcmd->SetParameterName("path",/*omittable=*/false);
     fTowerMapcmd->SetGuidance("Write per-tower geometry map (one row per tower) to the given CSV path");
+    fTowerMapcmd->AvailableForStates(G4State_PreInit);
 }
 
 

--- a/src/DREMTubesDetectorConstruction.cc
+++ b/src/DREMTubesDetectorConstruction.cc
@@ -16,6 +16,10 @@
 //
 #include <random>
 #include <iostream>
+#include <fstream>
+#include <iomanip>
+#include <algorithm>
+#include "G4Threading.hh"
 #include "G4Material.hh"
 #include "G4NistManager.hh"
 #include "G4Box.hh"
@@ -72,6 +76,12 @@ DREMTubesGeoMessenger::DREMTubesGeoMessenger(DREMTubesDetectorConstruction* DetC
     fVerrotcmd->SetGuidance("Lift up calorimeter from back side (default deg)");
     fVerrotcmd->SetDefaultUnit("deg");
     fVerrotcmd->SetDefaultValue(0.);
+    fFiberMapcmd = new G4UIcmdWithAString("/tbgeo/fibermap", this);
+    fFiberMapcmd->SetParameterName("path",/*omittable=*/false);
+    fFiberMapcmd->SetGuidance("Write per-fiber geometry map (one row per SiPM fiber) to the given CSV path");
+    fTowerMapcmd = new G4UIcmdWithAString("/tbgeo/towermap", this);
+    fTowerMapcmd->SetParameterName("path",/*omittable=*/false);
+    fTowerMapcmd->SetGuidance("Write per-tower geometry map (one row per tower) to the given CSV path");
 }
 
 
@@ -86,6 +96,8 @@ DREMTubesGeoMessenger::~DREMTubesGeoMessenger(){
     delete fYshiftcmd;
     delete fOrzrotcmd;
     delete fVerrotcmd;
+    delete fFiberMapcmd;
+    delete fTowerMapcmd;
 }
 
 //Messenger SetNewValue virtual method from base class
@@ -107,6 +119,14 @@ void DREMTubesGeoMessenger::SetNewValue(G4UIcommand* command, G4String newValue)
     else if(command == fVerrotcmd){
         fDetConstruction->SetVerrot(fVerrotcmd->GetNewDoubleValue(newValue));
         G4cout<<"tbgeo: ver-rotated test-beam setup by "<<fDetConstruction->GetVerrot()<<" rad"<<G4endl;
+    }
+    else if(command == fFiberMapcmd){
+        fDetConstruction->SetFiberMapPath(newValue);
+        G4cout<<"tbgeo: per-fiber geometry map will be written to "<<newValue<<G4endl;
+    }
+    else if(command == fTowerMapcmd){
+        fDetConstruction->SetTowerMapPath(newValue);
+        G4cout<<"tbgeo: per-tower geometry map will be written to "<<newValue<<G4endl;
     }
 }
 
@@ -403,8 +423,16 @@ G4VPhysicalVolume* DREMTubesDetectorConstruction::DefineVolumes() {
     G4double tuberadius = 1.0*mm;
     G4double dtubeY=sq3*tuberadius;
     G4double dtubeX=2.*tuberadius;
-    G4double moduleX = (2*NofFiberscolumn+1)*tuberadius; 
+
+    //Reset the per-fiber map buffers for this geometry build (see WriteFiberMap)
+    //
+    fTubeRadius = tuberadius;
+    fModulePlacements.clear();
+    fFiberLocals.clear();
+    G4double moduleX = (2*NofFiberscolumn+1)*tuberadius;
     G4double moduleY = (NofFibersrow-1.)*dtubeY+4.*tuberadius*sq3m1;
+    fModuleX = moduleX; //store module footprint for the tower map
+    fModuleY = moduleY;
 //  side of hexagon in which tube is inscribed
 //    G4double side=tuberadius*2*sq3m1;
 
@@ -650,8 +678,10 @@ G4VPhysicalVolume* DREMTubesDetectorConstruction::DefineVolumes() {
               m_x = -dtubeX*NofFiberscolumn*column+ dtubeX*NofFiberscolumn*(NofmodulesX-1)/2;
               m_y = row*NofFibersrow*dtubeY-NofFibersrow*dtubeY*(NofmodulesY-1)/2;
             }	     	    
-            if(modflag[ii]>=0) {        
+            if(modflag[ii]>=0) {
               copynumbermodule = modflag[ii];
+              //Record this module placement for the per-fiber map
+              fModulePlacements.push_back({copynumbermodule, m_x, m_y, column, row});
 //              copynumbermodule = (1+column)+(row*NofmodulesX);
 //	      std::cout << " column " << column << " row " << row << " cpnm " << copynumbermodule << std::endl;
 // setup for 90 deg rotation of modules
@@ -960,6 +990,8 @@ G4VPhysicalVolume* DREMTubesDetectorConstruction::DefineVolumes() {
                 vec_SiPM.setZ(fiberZ/2+SiPMZ/2-0.18);
             
                 copynumber = ((NofFibersrow/2)*column+row/2);
+                //Record this scintillating fiber (local to the module) for the per-fiber map
+                fFiberLocals.push_back({'S', column, row, copynumber, S_x, S_y, S_name});
                 auto logic_S_fiber = constructscinfiber(tolerance,
                                                         tuberadius,
                                                         fiberZ,
@@ -1036,7 +1068,9 @@ G4VPhysicalVolume* DREMTubesDetectorConstruction::DefineVolumes() {
                 vec_SiPM.setZ(fiberZ/2+SiPMZ/2-0.18);
 
                 copynumber = ((NofFibersrow/2)*column+row/2);
-                        
+                //Record this Cherenkov fiber (local to the module) for the per-fiber map
+                fFiberLocals.push_back({'C', column, row, copynumber, C_x, C_y, C_name});
+
                 auto logic_C_fiber = constructcherfiber(tolerance,
                                                         tuberadius,
                                                         fiberZ,
@@ -1164,8 +1198,187 @@ G4VPhysicalVolume* DREMTubesDetectorConstruction::DefineVolumes() {
 
     // Return physical world
     //
+    //Optionally dump the per-fiber geometry map (once, on the master thread)
+    //
+    if(!fFiberMapPath.empty() && G4Threading::IsMasterThread()){
+        WriteFiberMap();
+    }
+    if(!fTowerMapPath.empty() && G4Threading::IsMasterThread()){
+        WriteTowerMap();
+    }
+
     return fWorldPV;
 
+}
+
+//
+// Write one CSV row per physical SiPM-readout fiber of the calorimeter.
+//
+// Only fibers belonging to SiPM towers (those listed in SiPMMod[]) are written:
+// their signals fill VectorSignals (scintillating) / VectorSignalsCher (Cherenkov).
+// PMT-readout towers are skipped. Fibers are placed once into a shared module
+// volume, so we cross the recorded fiber-local table (fFiberLocals) with every
+// SiPM module placement (fModulePlacements). Coordinates are in the
+// calorimeter-surface frame with NO rotation applied (neither the platform tilt,
+// which lives above this frame, nor the irot 90 deg module rotation).
+//
+void DREMTubesDetectorConstruction::WriteFiberMap() const {
+
+    if(fModulePlacements.empty() || fFiberLocals.empty()){
+        G4cerr << "WriteFiberMap: no fibers/modules recorded, nothing to write." << G4endl;
+        return;
+    }
+
+    auto globalX = [](const ModulePlacement& m, const FiberLocal& f){ return m.mx + f.lx; };
+    auto globalY = [](const ModulePlacement& m, const FiberLocal& f){ return m.my + f.ly; };
+
+    // Geometric row/column: rank the distinct x (column) and y (row) positions of
+    // the SiPM fibers only. Two positions closer than tol are the same row/column;
+    // tol is well below the ~1 mm minimum tube spacing but far above float noise.
+    const G4double tol = 0.3*fTubeRadius;
+    std::vector<G4double> allX, allY;
+    for(const auto& m : fModulePlacements){
+        if(GetSiPMTower(m.towerID) < 0) continue; // PMT tower: skip
+        for(const auto& f : fFiberLocals){
+            allX.push_back(globalX(m,f));
+            allY.push_back(globalY(m,f));
+        }
+    }
+    auto buildReps = [tol](std::vector<G4double> v){
+        std::sort(v.begin(), v.end());
+        std::vector<G4double> reps;
+        for(G4double x : v){
+            if(reps.empty() || x - reps.back() > tol) reps.push_back(x);
+        }
+        return reps;
+    };
+    const std::vector<G4double> xReps = buildReps(allX);
+    const std::vector<G4double> yReps = buildReps(allY);
+    auto rankOf = [tol](const std::vector<G4double>& reps, G4double x){
+        int i = (int)(std::upper_bound(reps.begin(), reps.end(), x + 0.5*tol) - reps.begin()) - 1;
+        return i < 0 ? 0 : i;
+    };
+
+    std::ofstream out(fFiberMapPath);
+    if(!out.is_open()){
+        G4cerr << "WriteFiberMap: cannot open '" << fFiberMapPath << "' for writing." << G4endl;
+        return;
+    }
+    out << std::fixed << std::setprecision(4);
+    out << "output_index,output_vector,fiber_type,x,y,"
+        << "global_row,global_col,local_row,local_col,tower_id,"
+        << "mod_grid_col,mod_grid_row,module_x,module_y,copynumber,pv_name\n";
+
+    unsigned long nrows = 0;
+    for(const auto& m : fModulePlacements){
+        const G4int siPMTower = GetSiPMTower(m.towerID);
+        if(siPMTower < 0) continue; // PMT tower: skip
+        for(const auto& f : fFiberLocals){
+            const G4double gx = globalX(m,f);
+            const G4double gy = globalY(m,f);
+
+            // Output-vector index, exactly as SteppingAction fills it for SiPM fibers.
+            const G4int outIndex = siPMTower*NoFibersTower + f.copyNumber;
+            const char* outVector = (f.type=='S') ? "VectorSignals" : "VectorSignalsCher";
+
+            const G4int localRow = f.rowInMod;                        // 0 = bottom
+            const G4int localCol = NofFiberscolumn - 1 - f.colInMod;  // 0 = left
+
+            out << outIndex << ','
+                << outVector << ','
+                << f.type << ','
+                << gx << ',' << gy << ','
+                << rankOf(yReps, gy) << ',' << rankOf(xReps, gx) << ','
+                << localRow << ',' << localCol << ','
+                << m.towerID << ','
+                << m.gridCol << ',' << m.gridRow << ','
+                << m.mx << ',' << m.my << ','
+                << f.copyNumber << ','
+                << f.pvName << '\n';
+            ++nrows;
+        }
+    }
+    out.close();
+    G4cout << "WriteFiberMap: wrote " << nrows << " SiPM fiber rows to '"
+           << fFiberMapPath << "' (" << xReps.size() << " columns x "
+           << yReps.size() << " rows)." << G4endl;
+}
+
+//
+// Write one CSV row per active tower of the calorimeter (both SiPM and PMT).
+//
+// One row per recorded module placement (fModulePlacements). Coordinates are the
+// module centre in the calorimeter-surface frame with NO rotation applied.
+//
+void DREMTubesDetectorConstruction::WriteTowerMap() const {
+
+    if(fModulePlacements.empty()){
+        G4cerr << "WriteTowerMap: no modules recorded, nothing to write." << G4endl;
+        return;
+    }
+
+    // Geometric row/column: rank the distinct module-centre x/y positions.
+    // Tower spacing is tens of mm, so a 1 mm tolerance safely separates them.
+    const G4double tol = fTubeRadius;
+    std::vector<G4double> allX, allY;
+    for(const auto& m : fModulePlacements){ allX.push_back(m.mx); allY.push_back(m.my); }
+    auto buildReps = [tol](std::vector<G4double> v){
+        std::sort(v.begin(), v.end());
+        std::vector<G4double> reps;
+        for(G4double x : v){
+            if(reps.empty() || x - reps.back() > tol) reps.push_back(x);
+        }
+        return reps;
+    };
+    const std::vector<G4double> xReps = buildReps(allX);
+    const std::vector<G4double> yReps = buildReps(allY);
+    auto rankOf = [tol](const std::vector<G4double>& reps, G4double x){
+        int i = (int)(std::upper_bound(reps.begin(), reps.end(), x + 0.5*tol) - reps.begin()) - 1;
+        return i < 0 ? 0 : i;
+    };
+
+    std::ofstream out(fTowerMapPath);
+    if(!out.is_open()){
+        G4cerr << "WriteTowerMap: cannot open '" << fTowerMapPath << "' for writing." << G4endl;
+        return;
+    }
+    out << std::fixed << std::setprecision(4);
+    out << "tower_id,readout,sipm_slot,x,y,global_row,global_col,"
+        << "mod_grid_col,mod_grid_row,output_scin_vector,output_cher_vector,"
+        << "output_index_base,n_fibers,module_dx,module_dy,module_z\n";
+
+    // Every tower holds the same number of tubes (scintillating + Cherenkov).
+    const G4int nFibers = NofFiberscolumn*NofFibersrow;
+
+    unsigned long nrows = 0;
+    for(const auto& m : fModulePlacements){
+        const G4int siPMTower = GetSiPMTower(m.towerID);
+        const bool isSiPM = (siPMTower >= 0);
+        // Output-vector mapping:
+        //  - SiPM tower: its fibers fill VectorSignals/VectorSignalsCher starting at
+        //    output_index_base = siPMTower*NoFibersTower (one entry per fiber).
+        //  - PMT tower:  its aggregate signal fills VecSPMT/VecCPMT at index tower_id.
+        const char* scinVec = isSiPM ? "VectorSignals"    : "VecSPMT";
+        const char* cherVec = isSiPM ? "VectorSignalsCher": "VecCPMT";
+        const G4int indexBase = isSiPM ? siPMTower*NoFibersTower : m.towerID;
+
+        out << m.towerID << ','
+            << (isSiPM ? "SiPM" : "PMT") << ','
+            << siPMTower << ','
+            << m.mx << ',' << m.my << ','
+            << rankOf(yReps, m.my) << ',' << rankOf(xReps, m.mx) << ','
+            << m.gridCol << ',' << m.gridRow << ','
+            << scinVec << ',' << cherVec << ','
+            << indexBase << ','
+            << nFibers << ','
+            << fModuleX << ',' << fModuleY << ','
+            << moduleZ << '\n';
+        ++nrows;
+    }
+    out.close();
+    G4cout << "WriteTowerMap: wrote " << nrows << " tower rows to '"
+           << fTowerMapPath << "' (" << xReps.size() << " columns x "
+           << yReps.size() << " rows)." << G4endl;
 }
 
 // Define constructscinfiber method()


### PR DESCRIPTION
## Summary

Adds two optional CSV dumps of the calorimeter geometry, written once when the geometry is built, plus Python scripts to visualize them.

### New UI commands
- `/tbgeo/fibermap <path>` — one row per **SiPM-readout fiber** (those filling `VectorSignals` / `VectorSignalsCher`): output index, fiber type, position (x, y), geometric global row/column and module-local row/column, tower id, copynumber, PV name.
- `/tbgeo/towermap <path>` — one row per **active tower** (SiPM and PMT): readout type, output-vector mapping (`VectorSignals`/`VectorSignalsCher` vs `VecSPMT`/`VecCPMT`), `output_index_base`, position and module footprint.

Both are written on the master thread at geometry construction, so a single-event run is enough. Add the command before `/run/initialize`.

### Conventions
- Coordinates are in the **calorimeter-surface frame with no rotation applied** (neither the `/tbgeo` platform tilt nor the `irot` 90° module rotation). Axes in mm.
- `global_row` / `global_col` use **geometric ranking** with a **bottom-left origin**.

### Implementation
- Fiber-local and module-placement data are recorded in `DefineVolumes()` at the exact placement points (no duplication of the geometry formulas), then dumped by `WriteFiberMap()` / `WriteTowerMap()`.

### Visualization
- `analysis/plot_fibers.py` — fibers as circles; `--tower ID` filter; `--color` / `--label` by any column.
- `analysis/plot_towers.py` — modules as rectangles; `--color` / `--label` by any column.

### Docs
- `FiberMap.md`, `TowerMap.md` document the CSV schemas and the plotting scripts.

## Notes surfaced by the maps (pre-existing config, not changed here)
- The active `modflag` block assigns `tower_id = 1` to **two** physical modules (and `11` is unused); the maps show both rows. `NoModulesActive = 80` while only 70 modules are actually placed.

## Verification
Built and run in the Geant4 dev container; verified row counts and index ranges (SiPM 0–4095, per-tower blocks), row/column monotonicity vs x/y, and the plots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)